### PR TITLE
feat: Improve metadata process job

### DIFF
--- a/src/job-handlers/process-metadata.ts
+++ b/src/job-handlers/process-metadata.ts
@@ -1,7 +1,7 @@
-import { IsNull } from 'typeorm'
+import { EntityManager, IsNull } from 'typeorm'
 import Queue from 'bull'
 import connection from '../connection'
-import { JobData } from '../jobs/process-metadata'
+import { JobData, processMetadata } from '../jobs/process-metadata'
 import { Attribute, Collection, Metadata, Token } from '../model'
 import { fetchMetadata, metadataParser } from '../mappings/util/metadata'
 
@@ -10,6 +10,28 @@ type MetadataType = {
     metadata: any
     uri: string
     last_updated_at: Date
+}
+async function* tokensInBatch(em: EntityManager, collectionId: string) {
+    let skip = 0
+    const limit = 500
+
+    while (true) {
+        // eslint-disable-next-line no-await-in-loop
+        const items = await em
+            .getRepository(Token)
+            .createQueryBuilder('token')
+            .select('token.id', 'token.collection_id')
+            .where('token.collection_id = :collectionId', { collectionId })
+            .skip(skip)
+            .take(limit)
+            .getMany()
+
+        yield items
+        if (items.length === 0 || items.length < limit) {
+            return
+        }
+        skip += items.length
+    }
 }
 
 export default async (job: Queue.Job<JobData>, done: Queue.DoneCallback) => {
@@ -115,6 +137,17 @@ export default async (job: Queue.Job<JobData>, done: Queue.DoneCallback) => {
     resource.metadata = metadata
 
     await em.save(resource)
+
+    if (jobData.type === 'collection' && jobData.allTokens === true && uriAttribute && uriAttribute.value.includes('{id}')) {
+        const batch = tokensInBatch(em, jobData.resourceId)
+
+        // eslint-disable-next-line no-restricted-syntax
+        for await (const tokens of batch) {
+            tokens.forEach((token) => {
+                processMetadata(token.id, 'token', true)
+            })
+        }
+    }
 
     done(null, { id: jobData.resourceId })
 }

--- a/src/job-handlers/worker.ts
+++ b/src/job-handlers/worker.ts
@@ -20,7 +20,10 @@ async function main() {
     console.info('handling jobs...')
 
     traitsQueue.process(2, `${__dirname}/compute-traits.js`)
-    metadataQueue.process(50, `${__dirname}/process-metadata.js`)
+    metadataQueue.process(
+        process.env.MAX_WORKER_CONCURRENCY ? parseInt(process.env.MAX_WORKER_CONCURRENCY, 10) : 50,
+        `${__dirname}/process-metadata.js`
+    )
     collectionStatsQueue.process(10, `${__dirname}/collection-stats.js`)
     fetchAccountQueue.process(5, `${__dirname}/fetch-account.js`)
     fetchCollectionExtraQueue.process(5, `${__dirname}/fetch-collection-extra.js`)

--- a/src/jobs/process-metadata.ts
+++ b/src/jobs/process-metadata.ts
@@ -1,7 +1,7 @@
 import Queue from 'bull'
 import { redisConfig } from './common'
 
-export type JobData = { resourceId: string; type: 'token' | 'collection'; force: boolean }
+export type JobData = { resourceId: string; type: 'token' | 'collection'; force: boolean; allTokens: boolean }
 
 export const metadataQueue = new Queue<JobData>('metadataQueue', {
     defaultJobOptions: { delay: 1000, attempts: 5, removeOnComplete: true },
@@ -11,8 +11,8 @@ export const metadataQueue = new Queue<JobData>('metadataQueue', {
     },
 })
 
-export const processMetadata = async (resourceId: string, type: JobData['type'], force = false) => {
-    metadataQueue.add({ resourceId, type, force }, { jobId: `${type}-${resourceId}` }).catch(() => {
+export const processMetadata = async (resourceId: string, type: JobData['type'], force = false, allTokens = false) => {
+    metadataQueue.add({ resourceId, type, force, allTokens }, { jobId: `${type}-${resourceId}` }).catch(() => {
         // eslint-disable-next-line no-console
         console.log('Closing connection as Redis is not available')
         metadataQueue.close(true)

--- a/src/mappings/multiTokens/events/attribute_set.ts
+++ b/src/mappings/multiTokens/events/attribute_set.ts
@@ -164,7 +164,7 @@ export async function attributeSet(
             }
             collection.attributeCount += 1
             await ctx.store.save(collection)
-            processMetadata(collection.id, 'collection', true)
+            processMetadata(collection.id, 'collection', true, true)
         }
     }
     if (token) {

--- a/src/mappings/util/metadata.ts
+++ b/src/mappings/util/metadata.ts
@@ -17,7 +17,7 @@ export async function fetchMetadata(url: string) {
             'accept-encoding': 'gzip;q=0,deflate,sdch',
         },
         withCredentials: false,
-        timeout: 5000,
+        timeout: 15000,
         maxRedirects: 1,
         httpsAgent: new https.Agent({ keepAlive: true, rejectUnauthorized: false }),
     })

--- a/src/server-extension/resolvers/refresh_metadata.ts
+++ b/src/server-extension/resolvers/refresh_metadata.ts
@@ -27,7 +27,7 @@ class RefreshMetadataResponse {
 }
 
 const rateLimitMap = new Map()
-const mins5 = 1000 * 60 * 5
+const mins10 = 1000 * 60 * 10
 
 @Resolver()
 export class RefreshMetadataResolver {
@@ -48,7 +48,7 @@ export class RefreshMetadataResolver {
             const rateLimit = rateLimitMap.get(collectionId)
 
             if (rateLimit) {
-                const timeLeft = Math.ceil((rateLimit + mins5 - Date.now()) / 1000)
+                const timeLeft = Math.ceil((rateLimit + mins10 - Date.now()) / 1000)
 
                 if (timeLeft > 0) {
                     return {

--- a/src/server-extension/resolvers/refresh_metadata.ts
+++ b/src/server-extension/resolvers/refresh_metadata.ts
@@ -33,7 +33,8 @@ export class RefreshMetadataResolver {
     @Query(() => RefreshMetadataResponse, { nullable: false })
     async refreshMetadata(
         @Arg('collectionId') collectionId: string,
-        @Arg('tokenId', () => BigInteger, { nullable: true }) tokenId: bigint
+        @Arg('tokenId', () => BigInteger, { nullable: true }) tokenId: bigint,
+        @Arg('allTokens') allTokens: boolean
     ): Promise<RefreshMetadataResponse> {
         const manager = await this.tx()
         let resource!: Collection | Token | null
@@ -59,7 +60,7 @@ export class RefreshMetadataResolver {
             return { status: RefreshMetadataResponseStatus.ERROR, error: 'Resource not found' }
         }
 
-        processMetadata(resource.id, isToken ? 'token' : 'collection', true)
+        processMetadata(resource.id, isToken ? 'token' : 'collection', true, allTokens)
 
         if (!isToken) {
             syncCollectionStats(collectionId)


### PR DESCRIPTION
- force all tokens in a collection to update metadata when collection attributes are changed. 
- force all tokens in a collection to update metadata when `allTokens` argument is passed to refreshMetadataQuery.
- add env variable `MAX_WORKER_CONCURRENCY` to adjust worker's concurrency.
- increase timeout from 5 seconds to 15 seconds. 