### PR TITLE
feat: add tokenId to marketplace pallet events broadcasted over SNS

### DIFF
--- a/src/mappings/marketplace/events/auction_finalized.ts
+++ b/src/mappings/marketplace/events/auction_finalized.ts
@@ -130,7 +130,7 @@ export async function auctionFinalized(
                     amount: listing.amount.toString(),
                     price: listing.price.toString(),
                     data: listing.data.toJSON(),
-                    tokenId: `${listing.makeAssetId.collection.collectionId}-${listing.makeAssetId.tokenId}`,
+                    tokenId: listing.makeAssetId.id,
                 },
                 winningBid: data.winningBid
                     ? {

--- a/src/mappings/marketplace/events/auction_finalized.ts
+++ b/src/mappings/marketplace/events/auction_finalized.ts
@@ -130,6 +130,7 @@ export async function auctionFinalized(
                     amount: listing.amount.toString(),
                     price: listing.price.toString(),
                     data: listing.data.toJSON(),
+                    tokenId: `${listing.makeAssetId.collection.collectionId}-${listing.makeAssetId.tokenId}`,
                 },
                 winningBid: data.winningBid
                     ? {

--- a/src/mappings/marketplace/events/bid_placed.ts
+++ b/src/mappings/marketplace/events/bid_placed.ts
@@ -128,7 +128,7 @@ export async function bidPlaced(
                     amount: listing.amount.toString(),
                     price: listing.price.toString(),
                     data: listing.data.toJSON(),
-                    tokenId: `${listing.makeAssetId.collection.collectionId}-${listing.makeAssetId.tokenId}`,
+                    tokenId: listing.makeAssetId.id,
                 },
                 lastBid: lastBid
                     ? {

--- a/src/mappings/marketplace/events/bid_placed.ts
+++ b/src/mappings/marketplace/events/bid_placed.ts
@@ -128,6 +128,7 @@ export async function bidPlaced(
                     amount: listing.amount.toString(),
                     price: listing.price.toString(),
                     data: listing.data.toJSON(),
+                    tokenId: `${listing.makeAssetId.collection.collectionId}-${listing.makeAssetId.tokenId}`,
                 },
                 lastBid: lastBid
                     ? {

--- a/src/mappings/marketplace/events/counter_offer_answered.ts
+++ b/src/mappings/marketplace/events/counter_offer_answered.ts
@@ -117,6 +117,7 @@ export async function counterOfferAnswered(
                 account: account.id,
                 listing: listing.id,
                 extrinsic: item.extrinsic.id,
+                tokenId: `${listing.makeAssetId.collection.collectionId}-${listing.makeAssetId.tokenId}`,
             },
         })
     }

--- a/src/mappings/marketplace/events/counter_offer_answered.ts
+++ b/src/mappings/marketplace/events/counter_offer_answered.ts
@@ -117,7 +117,7 @@ export async function counterOfferAnswered(
                 account: account.id,
                 listing: listing.id,
                 extrinsic: item.extrinsic.id,
-                tokenId: `${listing.makeAssetId.collection.collectionId}-${listing.makeAssetId.tokenId}`,
+                tokenId: listing.takeAssetId.id,
             },
         })
     }

--- a/src/mappings/marketplace/events/counter_offer_placed.ts
+++ b/src/mappings/marketplace/events/counter_offer_placed.ts
@@ -118,6 +118,7 @@ export async function counterOfferPlaced(
                 account: account.id,
                 listing: listing.id,
                 extrinsic: item.extrinsic.id,
+                tokenId: `${listing.makeAssetId.collection.collectionId}-${listing.makeAssetId.tokenId}`,
             },
         })
     }

--- a/src/mappings/marketplace/events/counter_offer_placed.ts
+++ b/src/mappings/marketplace/events/counter_offer_placed.ts
@@ -118,7 +118,7 @@ export async function counterOfferPlaced(
                 account: account.id,
                 listing: listing.id,
                 extrinsic: item.extrinsic.id,
-                tokenId: `${listing.makeAssetId.collection.collectionId}-${listing.makeAssetId.tokenId}`,
+                tokenId: listing.takeAssetId.id,
             },
         })
     }

--- a/src/mappings/marketplace/events/counter_offer_removed.ts
+++ b/src/mappings/marketplace/events/counter_offer_removed.ts
@@ -90,6 +90,7 @@ export async function counterOfferRemoved(
                 account: account.id,
                 listing: listing.id,
                 extrinsic: item.extrinsic.id,
+                tokenId: `${listing.makeAssetId.collection.collectionId}-${listing.makeAssetId.tokenId}`,
             },
         })
     }

--- a/src/mappings/marketplace/events/counter_offer_removed.ts
+++ b/src/mappings/marketplace/events/counter_offer_removed.ts
@@ -33,8 +33,8 @@ function getEvent(
         id: item.id,
         name: MarketplaceCounterOfferRemoved.name,
         extrinsic: item.extrinsic?.id ? new Extrinsic({ id: item.extrinsic.id }) : null,
-        collectionId: listing.makeAssetId.collection.id,
-        tokenId: listing.makeAssetId.id,
+        collectionId: listing.takeAssetId.collection.id,
+        tokenId: listing.takeAssetId.id,
         data: new MarketplaceCounterOfferRemoved({
             listing: listing.id,
             creator: data.creator,
@@ -45,7 +45,7 @@ function getEvent(
         event,
         new AccountTokenEvent({
             id: item.id,
-            token: new Token({ id: listing.makeAssetId.id }),
+            token: new Token({ id: listing.takeAssetId.id }),
             from: account,
             event,
         }),
@@ -64,7 +64,7 @@ export async function counterOfferRemoved(
     const listing = await ctx.store.findOneOrFail<Listing>(Listing, {
         where: { id: listingId },
         relations: {
-            makeAssetId: {
+            takeAssetId: {
                 collection: true,
                 bestListing: true,
             },

--- a/src/mappings/marketplace/events/counter_offer_removed.ts
+++ b/src/mappings/marketplace/events/counter_offer_removed.ts
@@ -90,7 +90,7 @@ export async function counterOfferRemoved(
                 account: account.id,
                 listing: listing.id,
                 extrinsic: item.extrinsic.id,
-                tokenId: `${listing.makeAssetId.collection.collectionId}-${listing.makeAssetId.tokenId}`,
+                tokenId: listing.takeAssetId.id,
             },
         })
     }

--- a/src/mappings/marketplace/events/listing_cancelled.ts
+++ b/src/mappings/marketplace/events/listing_cancelled.ts
@@ -106,6 +106,7 @@ export async function listingCancelled(
                     },
                     data: listing.data.toJSON(),
                     state: listing.state.toJSON(),
+                    tokenId: `${listing.makeAssetId.collection.collectionId}-${listing.makeAssetId.tokenId}`,
                 },
                 extrinsic: item.extrinsic.id,
             },

--- a/src/mappings/marketplace/events/listing_cancelled.ts
+++ b/src/mappings/marketplace/events/listing_cancelled.ts
@@ -106,7 +106,7 @@ export async function listingCancelled(
                     },
                     data: listing.data.toJSON(),
                     state: listing.state.toJSON(),
-                    tokenId: `${listing.makeAssetId.collection.collectionId}-${listing.makeAssetId.tokenId}`,
+                    tokenId: listing.makeAssetId.id,
                 },
                 extrinsic: item.extrinsic.id,
             },

--- a/src/mappings/marketplace/events/listing_created.ts
+++ b/src/mappings/marketplace/events/listing_created.ts
@@ -83,10 +83,9 @@ export async function listingCreated(
     const data = getEventData(ctx, item)
     if (!data) return undefined
     const listingId = data.listingId.substring(2)
-    const tokenId = `${data.listing.makeAssetId.collectionId}-${data.listing.makeAssetId.tokenId}`
     const [makeAssetId, takeAssetId, account] = await Promise.all([
         ctx.store.findOne<Token>(Token, {
-            where: { id: tokenId },
+            where: { id: `${data.listing.makeAssetId.collectionId}-${data.listing.makeAssetId.tokenId}` },
             relations: {
                 bestListing: true,
             },
@@ -193,7 +192,9 @@ export async function listingCreated(
                     },
                     data: listing.data.toJSON(),
                     state: listing.state.toJSON(),
-                    tokenId,
+                    type: listing.type.toString(),
+                    makeAssetId: makeAssetId.id,
+                    takeAssetId: takeAssetId.id,
                 },
                 extrinsic: item.extrinsic.id,
             },

--- a/src/mappings/marketplace/events/listing_created.ts
+++ b/src/mappings/marketplace/events/listing_created.ts
@@ -83,9 +83,10 @@ export async function listingCreated(
     const data = getEventData(ctx, item)
     if (!data) return undefined
     const listingId = data.listingId.substring(2)
+    const tokenId = `${data.listing.makeAssetId.collectionId}-${data.listing.makeAssetId.tokenId}`
     const [makeAssetId, takeAssetId, account] = await Promise.all([
         ctx.store.findOne<Token>(Token, {
-            where: { id: `${data.listing.makeAssetId.collectionId}-${data.listing.makeAssetId.tokenId}` },
+            where: { id: tokenId },
             relations: {
                 bestListing: true,
             },
@@ -192,6 +193,7 @@ export async function listingCreated(
                     },
                     data: listing.data.toJSON(),
                     state: listing.state.toJSON(),
+                    tokenId,
                 },
                 extrinsic: item.extrinsic.id,
             },

--- a/src/mappings/marketplace/events/listing_filled.ts
+++ b/src/mappings/marketplace/events/listing_filled.ts
@@ -157,7 +157,7 @@ export async function listingFilled(
                     },
                     data: listing.data.toJSON(),
                     state: listing.state.toJSON(),
-                    tokenId: `${listing.makeAssetId.collection.collectionId}-${listing.makeAssetId.tokenId}`,
+                    tokenId: listing.makeAssetId.id,
                 },
                 buyer: { id: data.buyer },
                 amountFilled: data.amountFilled,

--- a/src/mappings/marketplace/events/listing_filled.ts
+++ b/src/mappings/marketplace/events/listing_filled.ts
@@ -157,6 +157,7 @@ export async function listingFilled(
                     },
                     data: listing.data.toJSON(),
                     state: listing.state.toJSON(),
+                    tokenId: `${listing.makeAssetId.collection.collectionId}-${listing.makeAssetId.tokenId}`,
                 },
                 buyer: { id: data.buyer },
                 amountFilled: data.amountFilled,


### PR DESCRIPTION
In nftio, when processing marketplace events (listings) there is a need of cache invalidation based on incoming event. However there is only listingId supplied in the event and it adds requirement of additional call to indexer to know what token is listing related to. By adding tokenId all required information will come in the event