### PR TITLE
[WAPI-1789] Fix balance field to include reserved tokens

### DIFF
--- a/src/server-extension/accounts-nft-summary.ts
+++ b/src/server-extension/accounts-nft-summary.ts
@@ -66,7 +66,7 @@ export class AccountsNftSummaryResolver {
             .innerJoin(Collection, 'collection', 'token.collection = collection.id')
             .select('collection.id', 'collectionId')
             .addSelect("collection.stats->>'floorPrice'", 'floorPrice')
-            .addSelect('SUM(token_account.balance)', 'totalBalance')
+            .addSelect('SUM(token_account.totalBalance)', 'totalBalance')
             .where('token_account.account IN (:...accountIds)', { accountIds })
             .groupBy('collection.id')
             .addGroupBy("collection.stats->>'floorPrice'")


### PR DESCRIPTION
## Summary
Fixed NFT summary calculation to use `totalBalance` instead of `balance` field to include reserved tokens in floor price estimation.

## Changes  
- Changed `token_account.balance` to `token_account.totalBalance` in accounts NFT summary query
- This ensures reserved tokens are included in floor price calculations

## Technical Details
The `totalBalance` field represents the complete token holdings (available + reserved tokens) while `balance` only includes immediately available tokens. For floor price estimation, we need to consider the total token holdings to provide accurate value calculations.

Database relationship: `totalBalance = balance + reservedBalance`