### PR TITLE
[NFTIO-3727] sanitize identity data

### DIFF
--- a/src/pallet/identity/processors/identity-set.ts
+++ b/src/pallet/identity/processors/identity-set.ts
@@ -5,10 +5,11 @@ import { Block, CommonContext, EventItem } from '~/contexts'
 import { getOrCreateAccount } from '~/util/entities'
 import * as mappings from '~/pallet/index'
 import { Data } from '~/pallet/common/types'
+import { safeString } from '~/util/tools'
 
 const dataToValue = (raw: Data) => {
     if (raw.__kind !== 'None') {
-        return hexToString(raw.value)
+        return safeString(hexToString(raw.value))
     }
 
     return null


### PR DESCRIPTION
Wrap hex-to-string conversion in safeString to ensure identity data is properly formatted for storage.