### PR TITLE
[PLA-2475] Index pallet/method for failed extrinsics

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -84,6 +84,12 @@ async function bootstrap() {
                     }
 
                     for (const call of block.calls) {
+                        // Calls of failed extrinsics are fetched (for pallet/method indexing)
+                        // but must not be processed as if they took effect.
+                        if (!call.success) {
+                            continue
+                        }
+
                         await callHandler(ctx, block.header, call)
                     }
 
@@ -270,30 +276,35 @@ async function processExtrinsics(
 
     if (call && (call.name === calls.fuelTanks.dispatch.name || call.name === calls.fuelTanks.dispatchAndTouch.name)) {
         const tankData = p.fuelTanks.utils.anyDispatch(call)
-        const tank = await ctx.store.findOneByOrFail<FuelTank>(FuelTank, {
+        // A failed dispatch can reference a tank that does not exist.
+        const tank = await ctx.store.findOneBy<FuelTank>(FuelTank, {
             id: unwrapAccount(tankData.tankId),
         })
 
-        fuelTank = new FuelTankData({
-            id: tank.id,
-            name: tank.name,
-            feePaid: 0n,
-            ruleSetId: tankData.ruleSetId,
-            paysRemainingFee:
-                'settings' in tankData && tankData.settings !== undefined ? tankData.settings.paysRemainingFee : null,
-            useNoneOrigin:
-                'settings' in tankData && tankData.settings !== undefined ? tankData.settings.useNoneOrigin : null,
-        })
+        if (tank) {
+            fuelTank = new FuelTankData({
+                id: tank.id,
+                name: tank.name,
+                feePaid: 0n,
+                ruleSetId: tankData.ruleSetId,
+                paysRemainingFee:
+                    'settings' in tankData && tankData.settings !== undefined
+                        ? tankData.settings.paysRemainingFee
+                        : null,
+                useNoneOrigin:
+                    'settings' in tankData && tankData.settings !== undefined ? tankData.settings.useNoneOrigin : null,
+            })
 
-        for (const eventItem of eventItems) {
-            if (eventItem.name !== events.balances.withdraw.name || eventItem.extrinsic?.id !== id) {
-                continue
-            }
+            for (const eventItem of eventItems) {
+                if (eventItem.name !== events.balances.withdraw.name || eventItem.extrinsic?.id !== id) {
+                    continue
+                }
 
-            const transfer = p.balances.events.withdraw(eventItem)
+                const transfer = p.balances.events.withdraw(eventItem)
 
-            if (transfer.who === tank.id) {
-                fuelTank.feePaid = transfer.amount
+                if (transfer.who === tank.id) {
+                    fuelTank.feePaid = transfer.amount
+                }
             }
         }
     }

--- a/src/processor.config.ts
+++ b/src/processor.config.ts
@@ -1,9 +1,11 @@
 import { SubstrateBatchProcessor } from '@subsquid/substrate-processor'
 import config from '~/util/config'
-import { events } from '~/type'
+import { calls, events } from '~/type'
 import { isRelay } from '~/util/tools'
 
 const getEventNames = (pallet: object): string[] => Object.values(pallet).map((event) => event.name)
+
+const getCallNames = (pallet: object): string[] => Object.values(pallet).map((call) => call.name)
 
 const matrixEvents: string[] = [...getEventNames(events.claims), ...getEventNames(events.polkadotXcm)]
 
@@ -71,12 +73,43 @@ const eventItems: string[] = [
     ),
 ]
 
+// Calls are subscribed by name (not only through their events) so that extrinsics
+// which fail on-chain — and therefore emit none of the subscribed events — still
+// arrive with their call data and get indexed with pallet/method/args populated.
+const matrixCalls: string[] = [
+    ...getCallNames(calls.claims),
+    ...getCallNames(calls.matrixUtility),
+    ...getCallNames(calls.polkadotXcm),
+]
+
+const relayCalls: string[] = [
+    ...getCallNames(calls.nominationPools),
+    ...getCallNames(calls.stakeExchange),
+    ...getCallNames(calls.staking),
+    ...getCallNames(calls.xcmPallet),
+]
+
+const commonCalls: string[] = [
+    ...getCallNames(calls.balances),
+    ...getCallNames(calls.fuelTanks),
+    ...getCallNames(calls.identity),
+    ...getCallNames(calls.marketplace),
+    ...getCallNames(calls.multiTokens),
+    ...getCallNames(calls.utility),
+]
+
+const callItems: string[] = [...new Set([...commonCalls, ...(isRelay() ? relayCalls : matrixCalls)])]
+
 export const processorConfig = new SubstrateBatchProcessor()
     .setRpcEndpoint(config.dataSource.chain)
     .setBlockRange({ from: config.dataSource.fromBlock })
     .addEvent({
         name: eventItems,
         call: true,
+        extrinsic: true,
+    })
+    .addCall({
+        name: callItems,
         extrinsic: true,
     })
     .setFields({
@@ -88,6 +121,7 @@ export const processorConfig = new SubstrateBatchProcessor()
             origin: true,
             args: true,
             name: true,
+            success: true,
         },
         extrinsic: {
             fee: true,


### PR DESCRIPTION
## Summary

Failed extrinsics are currently indexed with `pallet: null, method: null, args: null` (154 rows on canary-matrix alone). This crashed platform-cloud GraphQL queries selecting `Extrinsic.pallet` in production — Sentry [PLATFORM-CLOUD-V3-1V](https://enjin.sentry.io/issues/7610739063/).

**Root cause:** the processor only fetches call data through `.addEvent({..., call: true})`, i.e. for calls that emitted a subscribed event. A failed extrinsic emits only extrinsic-level events (fee `Balances.Withdraw`, `System.ExtrinsicFailed`) which carry no call linkage, so `extrinsic.call` is `undefined` in `processExtrinsics` and pallet/method are stored as null — even though the call data exists on-chain regardless of dispatch outcome.

## Changes

- **`processor.config.ts`**: subscribe to the relevant pallets' calls by name via `.addCall({name, extrinsic: true})`, mirroring the existing event subscription lists (common: balances, fuelTanks, identity, marketplace, multiTokens, utility; matrix: claims, matrixUtility, polkadotXcm; relay: nominationPools, stakeExchange, staking, xcmPallet). Name-scoped subscription keeps data volume flat — blocks with successful calls of these pallets are already fetched via their events; only the (rare) failed ones are added. Inherents stay unsubscribed, so the processor does not start receiving every block.
- **`main.ts`**: skip failed calls in the `callHandler` loop — their call data is fetched for indexing, but they must not be processed as if they took effect (`call.success` added to field selection).
- **`main.ts`**: fuel tank dispatch lookup switched from `findOneByOrFail` to `findOneBy` — a failed `FuelTanks.dispatch` can reference a tank that was never created, which would previously have thrown and crashed the batch.

## Notes

- Fixes indexing going forward; existing null rows need a reindex or one-off backfill to be repaired.
- `tsc --noEmit`, `eslint` and `prettier --check` clean.

Linear: PLA-2475

🤖 Generated with [Claude Code](https://claude.com/claude-code)