### PR TITLE
[PLA-2482] Persist requireAccount and coveragePolicy on FuelTankCreated

### DIFF
--- a/src/pallet/fuel-tanks/processors/fuel-tank-created.ts
+++ b/src/pallet/fuel-tanks/processors/fuel-tank-created.ts
@@ -60,9 +60,7 @@ export async function fuelTankCreated(
         isFrozen: false,
         accountCount: 0,
         providesDeposit: providesDeposit ?? false,
-        coveragePolicy: call.descriptor.coveragePolicy
-            ? CoveragePolicy[call.descriptor.coveragePolicy.__kind]
-            : null,
+        coveragePolicy: call.descriptor.coveragePolicy ? CoveragePolicy[call.descriptor.coveragePolicy.__kind] : null,
         userAccountManagement,
     })
 

--- a/src/pallet/fuel-tanks/processors/fuel-tank-created.ts
+++ b/src/pallet/fuel-tanks/processors/fuel-tank-created.ts
@@ -3,6 +3,7 @@ import { randomBytes } from 'crypto'
 import { CallNotDefinedError } from '~/util/errors'
 import { safeString } from '~/util/tools'
 import {
+    CoveragePolicy,
     Event as EventModel,
     Extrinsic,
     FuelTank,
@@ -50,7 +51,6 @@ export async function fuelTankCreated(
         //  'providesDeposit' in callData.descriptor ? callData.descriptor.providesDeposit : false,
         providesDeposit = call.descriptor.providesDeposit
     }
-    //  'coveragePolicy' in callData.descriptor ? CoveragePolicy[callData.descriptor.coveragePolicy.__kind] : null,
 
     const fuelTank = new FuelTank({
         id: tankAccount.id,
@@ -60,7 +60,9 @@ export async function fuelTankCreated(
         isFrozen: false,
         accountCount: 0,
         providesDeposit: providesDeposit ?? false,
-        coveragePolicy: null,
+        coveragePolicy: call.descriptor.coveragePolicy
+            ? CoveragePolicy[call.descriptor.coveragePolicy.__kind]
+            : null,
         userAccountManagement,
     })
 
@@ -94,8 +96,10 @@ export async function fuelTankCreated(
         for (const ruleSet of call.descriptor.ruleSets) {
             const index = ruleSet[0]
             let rules = ruleSet[1]
+            let requireAccount = false
 
             if (!Array.isArray(rules)) {
+                requireAccount = rules.requireAccount
                 rules = rules.rules
             }
 
@@ -118,6 +122,7 @@ export async function fuelTankCreated(
                 tank: fuelTank,
                 index,
                 isFrozen: false,
+                requireAccount,
                 isPermittedExtrinsicsEmpty: permittedExtrinsics === undefined || permittedExtrinsics.length === 0,
                 isPermittedExtrinsicsNull: permittedExtrinsics === undefined,
                 whitelistedCallers,


### PR DESCRIPTION
## Summary
Reported by Brad: `CreateFuelTank` with `ruleSets[0].requireAccount: true` produced a tank whose rule set shows `requireAccount` unset.

The write side is correct — the encoded `create_fuel_tank` call carries the flag (verified byte-level against the codec at spec 1031, matching live Enjin Matrix). The bug is in indexing: `fuelTankCreated` destructures only `rules` from the v1030+ `RuleSetDescriptor` and never passes `requireAccount` into the `FuelTankRuleSet` model, so the column stays NULL for every tank created via `create_fuel_tank` / `force_create_fuel_tank`. `ruleSetInserted` already persists the same field correctly.

The same processor also hardcoded `coveragePolicy: null` (the correct mapping sat next to it in a comment), losing e.g. `FEES_AND_DEPOSIT` until the manual `sync-fuel-tanks` job runs.

## Changes
- `fuelTankCreated`: read `requireAccount` from the rule-set descriptor (defaults to `false` for pre-v1030 shapes) and persist it on `FuelTankRuleSet`.
- `fuelTankCreated`: map `descriptor.coveragePolicy` onto the `FuelTank` model instead of hardcoding `null`.

## Backfill
Existing rows can be repaired with the manual `sync-fuel-tank-rule-sets` / `sync-fuel-tanks` jobs (refresh-entity), which already read both fields from chain state correctly.

## Verification
- `tsc --noEmit` and `eslint` pass.
- Encoder round-trip probe: encoded `create_fuel_tank` with `requireAccount` true/false differs by exactly the expected descriptor byte, confirming the data reaches the chain and only the read side dropped it.

Linear: PLA-2482

🤖 Generated with [Claude Code](https://claude.com/claude-code)