### PR TITLE
[PLA-2483] Fix WhitelistedPallets mapping in fuel-tank rule-set sync

### DIFF
--- a/src/pallet/fuel-tanks/utils.ts
+++ b/src/pallet/fuel-tanks/utils.ts
@@ -86,7 +86,10 @@ function convertTypeToModel(
     const value = match(rule)
         .with({ __kind: 'WhitelistedCallers' }, (r) => r.value.map((account) => account))
         .with({ __kind: 'WhitelistedCollections' }, (r) => r.value.map((c) => c.toString()))
-        .with({ __kind: 'WhitelistedPallets' }, (r) => r.value.map((p) => `${p.__kind}:${p.value.__kind}`))
+        .with({ __kind: 'WhitelistedPallets' }, (r) =>
+            // Chain-storage-derived entries know only the pallet name; store it alone then.
+            r.value.map((p) => (p.value.__kind ? `${p.__kind}:${p.value.__kind}` : p.__kind))
+        )
         .with({ __kind: 'MaxFuelBurnPerTransaction' }, (r) => new MaxFuelBurnPerTransaction({ value: r.value }))
         .with(
             { __kind: 'UserFuelBudget' },

--- a/src/worker/jobs/metadata/sync-fuel-tank-rule-sets.ts
+++ b/src/worker/jobs/metadata/sync-fuel-tank-rule-sets.ts
@@ -1,4 +1,5 @@
 import type { ApiPromise } from '@polkadot/api'
+import { hexToString } from '@polkadot/util'
 import { FuelTank, FuelTankRuleSet, PermittedExtrinsics } from '~/model'
 import { connectionManager } from '~/contexts'
 import { Job } from 'bullmq'
@@ -40,6 +41,28 @@ function big(v: { toString?: () => string } | bigint | number | string | null | 
 
 function capitalizeKind(s: string): string {
     return s.charAt(0).toUpperCase() + s.slice(1)
+}
+
+/**
+ * WhitelistedPallets storage keeps only the pallet name as SCALE Bytes (hex in storage JSON,
+ * e.g. 0x5574696c697479 = "Utility"); legacy codec shapes carry {type, value:{type}} call
+ * variants. Only the pallet name is knowable here, so the method __kind stays empty and
+ * rulesToMap stores the plain pallet name.
+ */
+function whitelistedPalletToCall(entry: unknown): Call {
+    if (entry && typeof entry === 'object') {
+        const p = entry as { type?: string; value?: { type?: string } }
+        if (typeof p.type === 'string') {
+            return {
+                __kind: capitalizeKind(p.type),
+                value: { __kind: p.value?.type ? capitalizeKind(p.value.type) : '' },
+            }
+        }
+    }
+
+    const s = String(entry ?? '')
+    const name = s.startsWith('0x') ? hexToString(s) : s
+    return { __kind: capitalizeKind(name), value: { __kind: '' } }
 }
 
 function callIndexToCall(api: ApiPromise, palletIndex: number, functionIndex: number): Call {
@@ -143,18 +166,12 @@ function jsonVariantToDescriptor(api: ApiPromise, kind: string, raw: unknown): D
             return { __kind: 'WhitelistedCollections', value: arr.filter((c) => c != null).map((c) => big(String(c))) }
         }
         case 'WhitelistedPallets': {
-            const arr = (Array.isArray(v) ? v : ((v.value as unknown[]) ?? [])) as {
-                type?: string
-                value?: { type?: string }
-            }[]
+            const arr = (
+                Array.isArray(v) ? v : (((v.whitelistedPallets ?? v.value) as unknown[] | undefined) ?? [])
+            ) as unknown[]
             return {
                 __kind: 'WhitelistedPallets',
-                value: arr.map((p) => ({
-                    __kind: (p.type ?? 'Unknown').charAt(0).toUpperCase() + (p.type ?? 'unknown').slice(1),
-                    value: {
-                        __kind: (p.value?.type ?? 'Unknown').charAt(0).toUpperCase() + (p.value?.type ?? 'x').slice(1),
-                    },
-                })),
+                value: arr.map(whitelistedPalletToCall),
             }
         }
         case 'MaxFuelBurnPerTransaction': {
@@ -241,12 +258,7 @@ function ruleCodecToDescriptor(api: ApiPromise, rule: { type: string; value: unk
         case 'whitelistedPallets':
             return {
                 __kind: 'WhitelistedPallets',
-                value: [...(v as unknown as Iterable<{ type: string; value: { type: string } }>)].map((p) => ({
-                    __kind: p.type.charAt(0).toUpperCase() + p.type.slice(1),
-                    value: {
-                        __kind: p.value.type.charAt(0).toUpperCase() + p.value.type.slice(1),
-                    },
-                })),
+                value: [...(v as unknown as Iterable<unknown>)].map(whitelistedPalletToCall),
             }
         case 'maxFuelBurnPerTransaction':
             return { __kind: 'MaxFuelBurnPerTransaction', value: big(v as { toString: () => string }) }


### PR DESCRIPTION
## Summary
Follow-up to #1921. The post-merge backfill run of `sync-fuel-tank-rule-sets` fixed `requireAccount`, but wiped `whitelistedPallets` on every tank that has that rule (e.g. tank `efRjXVz8…` now returns `whitelistedPallets: []` while on-chain the rule holds `Utility` + `MultiTokens`).

Two defects in the sync's WhitelistedPallets mapping:
- `jsonVariantToDescriptor` read the payload from `v.value`, but the storage JSON key is `whitelistedPallets` — the array was always empty, so each sync overwrote good rows with `[]`.
- Both the JSON and typed-codec paths assumed `{type, value:{type}}` call-variant items, while the chain stores the rule as SCALE Bytes pallet names (`0x5574696c697479` = `"Utility"`).

## Changes
- New `whitelistedPalletToCall` helper: hex-decodes Bytes pallet names, still accepts legacy `{type, value:{type}}` shapes; used by both mapping paths.
- `rulesToMap`: entries without a method `__kind` are stored as the plain pallet name (`"Utility"`); call-derived entries keep the `"Pallet:Method"` format. The `compatible-fuel-tanks` SQL already matches both formats.

## Backfill
Re-running `sync-fuel-tank-rule-sets` (refresh-entity) after deploy restores the wiped rows from chain state.

## Verification
- `tsc --noEmit`, prettier, eslint pass.
- On-chain storage shape confirmed via `api.query.fuelTanks.tanks` on Enjin Matrix (spec 1031): `WhitelistedPallets` payload key is `whitelistedPallets`, items are hex-encoded pallet names.

Linear: PLA-2483

🤖 Generated with [Claude Code](https://claude.com/claude-code)