### PR TITLE
[NFTIO-3950] Fix token creation and derived hot changes

### DIFF
--- a/src/pallet/multi-tokens/processors/token-created-call.ts
+++ b/src/pallet/multi-tokens/processors/token-created-call.ts
@@ -1,5 +1,6 @@
 import { ForceMint, Mint } from '~/pallet/multi-tokens/calls'
 import { TokenCreated } from '~/pallet/multi-tokens/events'
+import { FlexibleMintParams } from '~/pallet/common/types'
 
 type TokenCreationCall = Mint | ForceMint
 type UnknownRecord = Record<string, unknown>
@@ -60,4 +61,8 @@ export function findTokenCreationCalls(call: unknown, event: TokenCreated): Toke
 export function selectTokenCreationCall(call: unknown, event: TokenCreated): TokenCreationCall | undefined {
     const matches = findTokenCreationCalls(call, event)
     return matches.length === 1 ? matches[0] : undefined
+}
+
+export function unwrapFlexibleMintParams(params: FlexibleMintParams): FlexibleMintParams {
+    return '__kind' in params && params.__kind === 'CreateOrMint' ? params.value : params
 }

--- a/src/pallet/multi-tokens/processors/token-created-call.ts
+++ b/src/pallet/multi-tokens/processors/token-created-call.ts
@@ -1,0 +1,63 @@
+import { ForceMint, Mint } from '~/pallet/multi-tokens/calls'
+import { TokenCreated } from '~/pallet/multi-tokens/events'
+
+type TokenCreationCall = Mint | ForceMint
+type UnknownRecord = Record<string, unknown>
+
+function isRecord(value: unknown): value is UnknownRecord {
+    return typeof value === 'object' && value !== null
+}
+
+function tokenIdFromParams(params: unknown): bigint | undefined {
+    if (!isRecord(params)) return undefined
+    if (typeof params.tokenId === 'bigint') return params.tokenId
+
+    return isRecord(params.value) && typeof params.value.tokenId === 'bigint' ? params.value.tokenId : undefined
+}
+
+function collectTokenCreationCalls(node: unknown, event: TokenCreated, matches: TokenCreationCall[]): void {
+    if (Array.isArray(node)) {
+        node.forEach((value) => {
+            collectTokenCreationCalls(value, event, matches)
+        })
+        return
+    }
+
+    if (!isRecord(node)) return
+
+    if (node.__kind === 'batch_mint' && node.collectionId === event.collectionId && Array.isArray(node.recipients)) {
+        for (const recipient of node.recipients) {
+            if (!isRecord(recipient) || tokenIdFromParams(recipient.params) !== event.tokenId) continue
+
+            matches.push({
+                collectionId: event.collectionId,
+                recipient: {
+                    __kind: 'Id',
+                    value: recipient.accountId as string,
+                },
+                params: recipient.params,
+            } as Mint)
+        }
+    } else if (
+        (node.__kind === 'mint' || node.__kind === 'force_mint') &&
+        node.collectionId === event.collectionId &&
+        tokenIdFromParams(node.params) === event.tokenId
+    ) {
+        matches.push(node as TokenCreationCall)
+    }
+
+    for (const value of Object.values(node)) {
+        collectTokenCreationCalls(value, event, matches)
+    }
+}
+
+export function findTokenCreationCalls(call: unknown, event: TokenCreated): TokenCreationCall[] {
+    const matches: TokenCreationCall[] = []
+    collectTokenCreationCalls(call, event, matches)
+    return matches
+}
+
+export function selectTokenCreationCall(call: unknown, event: TokenCreated): TokenCreationCall | undefined {
+    const matches = findTokenCreationCalls(call, event)
+    return matches.length === 1 ? matches[0] : undefined
+}

--- a/src/pallet/multi-tokens/processors/token-created.ts
+++ b/src/pallet/multi-tokens/processors/token-created.ts
@@ -22,7 +22,7 @@ import { hexToString } from '@polkadot/util'
 import { safeString } from '~/util/tools'
 import { Token as StoredToken } from '~/pallet/multi-tokens/storage/types'
 import { calls } from '~/type'
-import { selectTokenCreationCall } from '~/pallet/multi-tokens/processors/token-created-call'
+import { selectTokenCreationCall, unwrapFlexibleMintParams } from '~/pallet/multi-tokens/processors/token-created-call'
 
 type TokenParams = DefaultMintParams | FlexibleMintParams | StoredToken
 
@@ -117,7 +117,7 @@ async function tokenFromCall(
             tokenId: event.tokenId,
         })
     } else if (call && 'params' in call) {
-        tokenParams = call.params
+        tokenParams = unwrapFlexibleMintParams(call.params)
     }
 
     if (tokenParams) {

--- a/src/pallet/multi-tokens/processors/token-created.ts
+++ b/src/pallet/multi-tokens/processors/token-created.ts
@@ -11,19 +11,20 @@ import {
 import { Block, CommonContext, EventItem } from '~/contexts'
 import * as mappings from '~/pallet/index'
 import { CreatePool } from '~/pallet/nomination-pools/calls'
-import { BatchMint, ForceMint, Mint } from '~/pallet/multi-tokens/calls'
+import { ForceMint, Mint } from '~/pallet/multi-tokens/calls'
 import { TokenCreated } from '~/pallet/multi-tokens/events'
-import { TokenMarketBehavior as TokenMarketBehavior500 } from '~/type/matrixV500'
-import { TokenMarketBehavior as TokenMarketBehavior1020 } from '~/type/matrixV1020'
 import { getOrCreateAccount } from '~/util/entities'
 import { getCapType, getFreezeState, isTokenFrozen } from '~/synchronize/common'
 import { EventHandlerResult } from '~/processor.handler'
 import { isDispatchCall, unwrapFuelTankCall } from '~/pallet/fuel-tanks/utils'
-import { Call } from '~/pallet/common/types'
+import { DefaultMintParams, FlexibleMintParams, TokenMarketBehavior } from '~/pallet/common/types'
 import { hexToString } from '@polkadot/util'
 import { safeString } from '~/util/tools'
+import { Token as StoredToken } from '~/pallet/multi-tokens/storage/types'
+import { calls } from '~/type'
+import { selectTokenCreationCall } from '~/pallet/multi-tokens/processors/token-created-call'
 
-type TokenMarketBehavior = TokenMarketBehavior500 | TokenMarketBehavior1020
+type TokenParams = DefaultMintParams | FlexibleMintParams | StoredToken
 
 async function getBehavior(
     ctx: CommonContext,
@@ -63,34 +64,19 @@ async function tokenFromCall(
     ctx: CommonContext,
     block: Block,
     event: TokenCreated,
-    call: Mint | ForceMint | CreatePool
+    call?: Mint | ForceMint | CreatePool,
+    useStorage = false
 ): Promise<Token> {
     const collection = await ctx.store.findOne<Collection>(Collection, {
         where: { id: event.collectionId.toString() },
     })
 
-    const tokenCall = call
-
     if (!collection) {
         throwFatalError(`[TokenCreated] We have not found collection ${event.collectionId.toString()}.`)
     }
 
-    let tokenId = event.tokenId
-    if ('params' in tokenCall) {
-        const params = tokenCall.params
-        if ('__kind' in params) {
-            if (params.__kind === 'CreateToken' || params.__kind === 'Mint') {
-                tokenId = params.tokenId
-            } else {
-                tokenId = params.value.tokenId
-            }
-        } else {
-            tokenId = params.tokenId
-        }
-    }
-
     const existingToken = await ctx.store.findOne<Token>(Token, {
-        where: { id: `${event.collectionId}-${tokenId}` },
+        where: { id: `${event.collectionId}-${event.tokenId}` },
     })
 
     let existingSupply = 0n
@@ -99,9 +85,9 @@ async function tokenFromCall(
     }
 
     const token = new Token({
-        id: `${event.collectionId}-${tokenId}`,
+        id: `${event.collectionId}-${event.tokenId}`,
         hidden: false,
-        tokenId: tokenId,
+        tokenId: event.tokenId,
         supply: existingSupply, // Updated on `Minted`
         cap: null, // params.cap,
         behavior: null, // params.behavior,
@@ -124,25 +110,21 @@ async function tokenFromCall(
         createdAt: new Date(block.timestamp ?? 0),
     })
 
-    let tokenParams = null
-
-    if ('capacity' in tokenCall) {
-        const data = await mappings.multiTokens.storage.tokens(block, {
+    let tokenParams: TokenParams | undefined
+    if (useStorage || (call && 'capacity' in call)) {
+        tokenParams = await mappings.multiTokens.storage.tokens(block, {
             collectionId: event.collectionId,
             tokenId: event.tokenId,
         })
-
-        if (data) {
-            tokenParams = data
-        }
+    } else if (call && 'params' in call) {
+        tokenParams = call.params
     }
 
-    if ('params' in tokenCall) {
-        tokenParams = tokenCall.params
-
+    if (tokenParams) {
         if ('sufficiency' in tokenParams) {
-            token.minimumBalance =
-                tokenParams.sufficiency?.__kind === 'Sufficient' ? tokenParams.sufficiency.minimumBalance : 1n
+            if (tokenParams.sufficiency?.__kind === 'Sufficient' && 'minimumBalance' in tokenParams.sufficiency) {
+                token.minimumBalance = tokenParams.sufficiency.minimumBalance
+            }
             token.unitPrice =
                 tokenParams.sufficiency?.__kind === 'Insufficient' ? (tokenParams.sufficiency.unitPrice ?? 1n) : 1n
         }
@@ -161,7 +143,7 @@ async function tokenFromCall(
 
         if ('metadata' in tokenParams) {
             token.nativeMetadata =
-                tokenParams.metadata !== undefined
+                tokenParams.metadata !== undefined && !('__kind' in tokenParams.metadata)
                     ? new NativeTokenMetadata({
                           decimalCount: tokenParams.metadata.decimalCount,
                           symbol: safeString(hexToString(tokenParams.metadata.symbol)),
@@ -170,11 +152,14 @@ async function tokenFromCall(
                     : null
         }
 
-        if ('behavior' in tokenParams) {
-            token.behavior =
-                tokenParams.behavior !== undefined
-                    ? await getBehavior(ctx, tokenParams.behavior as TokenMarketBehavior)
-                    : null
+        const behavior =
+            'behavior' in tokenParams
+                ? tokenParams.behavior
+                : 'marketBehavior' in tokenParams
+                  ? tokenParams.marketBehavior
+                  : undefined
+        if (behavior !== undefined) {
+            token.behavior = await getBehavior(ctx, behavior)
         }
 
         if ('cap' in tokenParams) {
@@ -191,26 +176,13 @@ async function tokenFromCall(
     return token
 }
 
-async function tokenFromBatchCall(
-    ctx: CommonContext,
-    block: Block,
-    event: TokenCreated,
-    call: BatchMint
-): Promise<Token[]> {
-    const tokens = await Promise.all(
-        call.recipients.map(async (recipient) => {
-            return tokenFromCall(ctx, block, event, {
-                recipient: {
-                    __kind: 'Id',
-                    value: recipient.accountId,
-                },
-                collectionId: call.collectionId,
-                params: recipient.params,
-            })
-        })
-    )
-
-    return tokens
+function unwrapComplexMintCall(item: EventItem): { call: unknown } | undefined {
+    if (!item.call) return undefined
+    if (isDispatchCall(item.call)) return { call: unwrapFuelTankCall(item.call) }
+    if (item.call.name === calls.matrixUtility.batch.name) {
+        return { call: mappings.matrixUtility.calls.batch(item.call) }
+    }
+    return undefined
 }
 
 export async function tokenCreated(
@@ -234,29 +206,15 @@ export async function tokenCreated(
         return mappings.multiTokens.events.tokenCreatedEventModel(item, event)
     }
 
-    if (item.call && isDispatchCall(item.call)) {
-        const unwrappedCall = unwrapFuelTankCall(item.call)
-        // @ts-ignore
-        const calls = unwrappedCall?.calls || []
-
-        // Process all batch_mint calls in the batch
-        for (const call of calls) {
-            const batchMintCall = call.value
-            if (batchMintCall?.__kind === 'batch_mint') {
-                const tokens = await tokenFromBatchCall(ctx, block, event, batchMintCall)
-                await ctx.store.save(tokens)
-            }
-        }
-
-        // If we processed any batch_mint calls, return early
-        if (calls.some((c: Call) => c.value.__kind === 'batch_mint')) {
-            return mappings.multiTokens.events.tokenCreatedEventModel(item, event)
-        }
-    }
-
     if (item.call) {
-        const call = mappings.multiTokens.utils.anyMint(item.call, event.collectionId, event.tokenId)
-        const token = await tokenFromCall(ctx, block, event, call)
+        const complexCall = unwrapComplexMintCall(item)
+        // Encoded children include failed and unexecuted calls. Trust call parameters only when one recipient matches
+        // the finalized event; otherwise hydrate that event's token from canonical storage.
+        const call =
+            complexCall === undefined
+                ? mappings.multiTokens.utils.anyMint(item.call, event.collectionId, event.tokenId)
+                : selectTokenCreationCall(complexCall.call, event)
+        const token = await tokenFromCall(ctx, block, event, call, complexCall !== undefined && call === undefined)
         await ctx.store.save(token)
     }
 

--- a/src/worker/jobs/traits/log-trait-token-hot-changes.ts
+++ b/src/worker/jobs/traits/log-trait-token-hot-changes.ts
@@ -18,7 +18,8 @@ interface HotChangeLogRow {
     }
 }
 
-const TOKEN_TRAIT_TOKEN_FILTER = `change->>'table' = 'trait_token' AND change->'fields'->>'token_id' = $1`
+const TOKEN_DERIVED_DATA_FILTER = `change->>'table' IN ('trait_token', 'token_rarity')
+    AND change->'fields'->>'token_id' = $1`
 
 export async function logTraitTokenHotChanges(job: Job<LogTraitTokenHotChangesData>): Promise<void> {
     const { tokenId, delete: shouldDelete = false } = job.data
@@ -27,7 +28,7 @@ export async function logTraitTokenHotChanges(job: Job<LogTraitTokenHotChangesDa
     const rows: HotChangeLogRow[] = await em.query(
         `SELECT block_height, index, change
          FROM squid_processor.hot_change_log
-         WHERE ${TOKEN_TRAIT_TOKEN_FILTER}
+         WHERE ${TOKEN_DERIVED_DATA_FILTER}
          ORDER BY block_height, index`,
         [tokenId]
     )
@@ -47,7 +48,7 @@ export async function logTraitTokenHotChanges(job: Job<LogTraitTokenHotChangesDa
 
     const removed: HotChangeLogRow[] = await em.query(
         `DELETE FROM squid_processor.hot_change_log
-         WHERE ${TOKEN_TRAIT_TOKEN_FILTER}
+         WHERE ${TOKEN_DERIVED_DATA_FILTER}
            AND change->>'kind' = 'delete'
          RETURNING block_height, index, change`,
         [tokenId]

--- a/tests/token-created-call.test.ts
+++ b/tests/token-created-call.test.ts
@@ -1,8 +1,13 @@
 import assert from 'node:assert/strict'
 import test from 'node:test'
 
-import { findTokenCreationCalls, selectTokenCreationCall } from '~/pallet/multi-tokens/processors/token-created-call'
+import {
+    findTokenCreationCalls,
+    selectTokenCreationCall,
+    unwrapFlexibleMintParams,
+} from '~/pallet/multi-tokens/processors/token-created-call'
 import { TokenCreated } from '~/pallet/multi-tokens/events'
+import { FlexibleMintParams } from '~/pallet/common/types'
 
 const event: TokenCreated = {
     collectionId: 4519n,
@@ -79,4 +84,28 @@ void test('rejects duplicate token IDs from a failed child before persistence', 
 
     assert.equal(matches.length, 3)
     assert.equal(selectTokenCreationCall(call, event), undefined)
+})
+
+void test('unwraps historical CreateOrMint parameters before token hydration', () => {
+    const params: FlexibleMintParams = {
+        __kind: 'CreateOrMint',
+        value: {
+            tokenId: 1n,
+            amount: 1n,
+            listingForbidden: true,
+            attributes: [],
+            metadata: {
+                decimalCount: 18,
+                name: '0x746f6b656e',
+                symbol: '0x544b4e',
+            },
+        },
+    }
+
+    const unwrapped = unwrapFlexibleMintParams(params)
+
+    assert.ok('listingForbidden' in unwrapped)
+    assert.equal(unwrapped.listingForbidden, true)
+    assert.ok('metadata' in unwrapped)
+    assert.equal(unwrapped.metadata?.decimalCount, 18)
 })

--- a/tests/token-created-call.test.ts
+++ b/tests/token-created-call.test.ts
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import { findTokenCreationCalls, selectTokenCreationCall } from '~/pallet/multi-tokens/processors/token-created-call'
+import { TokenCreated } from '~/pallet/multi-tokens/events'
+
+const event: TokenCreated = {
+    collectionId: 4519n,
+    tokenId: 1n,
+    issuer: {
+        __kind: 'Root',
+    },
+    initialSupply: 1n,
+}
+
+const recipient = (tokenId: bigint, metadata: string) => ({
+    accountId: '0x01',
+    params: {
+        __kind: 'CreateToken',
+        tokenId,
+        initialSupply: 1n,
+        listingForbidden: false,
+        attributes: [],
+        metadata: {
+            decimalCount: 0,
+            name: metadata,
+            symbol: '0x',
+        },
+    },
+})
+
+const batchMint = (...recipients: ReturnType<typeof recipient>[]) => ({
+    __kind: 'MultiTokens',
+    value: {
+        __kind: 'batch_mint',
+        collectionId: 4519n,
+        recipients,
+    },
+})
+
+void test('uses the only matching nested batchMint recipient', () => {
+    const call = {
+        calls: [batchMint(recipient(1n, '0x7265616c'))],
+        continueOnFailure: false,
+    }
+
+    const selected = selectTokenCreationCall(call, event)
+
+    assert.ok(selected && 'params' in selected)
+    assert.ok('tokenId' in selected.params)
+    assert.equal(selected.params.tokenId, event.tokenId)
+})
+
+void test('rejects an ambiguous match when a failed child contains token 1 and token 777', () => {
+    const call = {
+        calls: [
+            batchMint(recipient(1n, '0x7265616c')),
+            batchMint(recipient(1n, '0x6661696c6564'), recipient(777n, '0x7068616e746f6d')),
+        ],
+        continueOnFailure: false,
+    }
+
+    const matches = findTokenCreationCalls(call, event)
+
+    assert.equal(matches.length, 2)
+    assert.equal(selectTokenCreationCall(call, event), undefined)
+})
+
+void test('rejects duplicate token IDs from a failed child before persistence', () => {
+    const call = {
+        calls: [
+            batchMint(recipient(1n, '0x7265616c')),
+            batchMint(recipient(1n, '0x6669727374'), recipient(1n, '0x7461696c')),
+        ],
+        continueOnFailure: false,
+    }
+
+    const matches = findTokenCreationCalls(call, event)
+
+    assert.equal(matches.length, 3)
+    assert.equal(selectTokenCreationCall(call, event), undefined)
+})


### PR DESCRIPTION
## Summary

- make `TokenCreated` event collection and token IDs authoritative
- associate complex nested mint calls only when one recipient uniquely matches the finalized event
- fall back to canonical token storage for ambiguous or unmatched nested calls
- save one token per `TokenCreated` event, preventing duplicate bulk-upsert targets and phantom recipients
- include `token_rarity` alongside `trait_token` when querying and removing derived token hot changes
- add regression tests for ambiguous and duplicate nested `batchMint` recipients

## Why

The `TokenCreated` processor previously walked every encoded nested `batch_mint` recipient for each observed event.
Encoded calls can include failed or unexecuted children, and their supplied token IDs could replace the event identity.
This allowed incorrect token rows and duplicate primary keys to reach a single PostgreSQL upsert.

Separately, the token hot-change cleanup filtered only `trait_token`, leaving related `token_rarity` changes behind.

## Impact

Each finalized `TokenCreated` event now produces at most one event-keyed token save. Ambiguous nested call data is not
trusted, preventing failed children from creating phantom tokens, overwriting identity, or causing PostgreSQL
duplicate-target failures. Derived hot-change cleanup now handles both trait and rarity rows for the token.

## Validation

- `pnpm run ci:lint`
- `pnpm exec tsc --noEmit`
- `pnpm run ci:prettier`
- `pnpm test` - 16 passing tests
- `pnpm run build`
