### PR TITLE
[PLA-2495] Accept a calls array on the /encoder endpoint

### DIFF
--- a/src/decoder/validation.ts
+++ b/src/decoder/validation.ts
@@ -7,7 +7,7 @@ import type {
 } from './types'
 import { NETWORKS } from './types'
 import { resolveNetwork } from './core'
-import type { EncodeRequest } from '../encoder/types'
+import type { EncodeCallInput, EncodeRequest } from '../encoder/types'
 
 export function validateDecodeRequest(
     body: unknown
@@ -108,6 +108,38 @@ export function validateDecodeRequest(
     }
 }
 
+function validateEncodeCallInput(
+    value: unknown,
+    label: string
+): { valid: true; data: EncodeCallInput } | { valid: false; error: string } {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        return { valid: false, error: `"${label}" must be an object` }
+    }
+
+    const call = value as Record<string, unknown>
+
+    if (typeof call.pallet !== 'string' || !call.pallet) {
+        return { valid: false, error: `"${label}.pallet" must be a non-empty string` }
+    }
+
+    if (typeof call.name !== 'string' || !call.name) {
+        return { valid: false, error: `"${label}.name" must be a non-empty string` }
+    }
+
+    if (call.args !== undefined && (typeof call.args !== 'object' || Array.isArray(call.args))) {
+        return { valid: false, error: `"${label}.args" must be an object` }
+    }
+
+    return {
+        valid: true,
+        data: {
+            pallet: call.pallet,
+            name: call.name,
+            args: call.args as Record<string, unknown> | undefined,
+        },
+    }
+}
+
 export function validateEncodeRequest(
     body: unknown
 ): { valid: true; data: EncodeRequest } | { valid: false; error: string } {
@@ -117,26 +149,39 @@ export function validateEncodeRequest(
 
     const req = body as Record<string, unknown>
 
-    if (req.call === undefined) {
-        return { valid: false, error: 'Missing "call" field' }
+    const hasCall = req.call !== undefined
+    const hasCalls = req.calls !== undefined
+
+    if (!hasCall && !hasCalls) {
+        return { valid: false, error: 'Missing "call" or "calls" field' }
     }
 
-    if (!req.call || typeof req.call !== 'object' || Array.isArray(req.call)) {
-        return { valid: false, error: '"call" must be an object' }
+    let call: EncodeCallInput | undefined
+    if (hasCall) {
+        const result = validateEncodeCallInput(req.call, 'call')
+        if (!result.valid) {
+            return result
+        }
+        call = result.data
     }
 
-    const call = req.call as Record<string, unknown>
+    let calls: EncodeCallInput[] | undefined
+    if (hasCalls) {
+        if (!Array.isArray(req.calls)) {
+            return { valid: false, error: '"calls" must be an array' }
+        }
+        if (req.calls.length === 0) {
+            return { valid: false, error: '"calls" must not be empty' }
+        }
 
-    if (typeof call.pallet !== 'string' || !call.pallet) {
-        return { valid: false, error: '"call.pallet" must be a non-empty string' }
-    }
-
-    if (typeof call.name !== 'string' || !call.name) {
-        return { valid: false, error: '"call.name" must be a non-empty string' }
-    }
-
-    if (call.args !== undefined && (typeof call.args !== 'object' || Array.isArray(call.args))) {
-        return { valid: false, error: '"call.args" must be an object' }
+        calls = []
+        for (const [index, item] of req.calls.entries()) {
+            const result = validateEncodeCallInput(item, `calls[${index}]`)
+            if (!result.valid) {
+                return result
+            }
+            calls.push(result.data)
+        }
     }
 
     if (req.network !== undefined) {
@@ -158,11 +203,8 @@ export function validateEncodeRequest(
     return {
         valid: true,
         data: {
-            call: {
-                pallet: call.pallet,
-                name: call.name,
-                args: call.args as Record<string, unknown> | undefined,
-            },
+            call,
+            calls,
             network: req.network,
             spec_version: req.spec_version,
         },

--- a/src/encoder/core.ts
+++ b/src/encoder/core.ts
@@ -19,6 +19,11 @@ function toKindFormat(input: EncodeCallInput): Record<string, unknown> {
 
 export async function encodeCall(input: EncodeCallInput, network: Network, specVersion: number): Promise<string> {
     const runtime = await getRuntimeCached(network, specVersion)
+
+    return encodeCallWithRuntime(input, runtime)
+}
+
+function encodeCallWithRuntime(input: EncodeCallInput, runtime: Awaited<ReturnType<typeof getRuntimeCached>>): string {
     const callData = toKindFormat(input)
     // Use jsonCodec to decode the call from JSON-compatible types (number/string) into
     // native SCALE types (bigint for U128/U64, etc.) before binary encoding.
@@ -28,8 +33,14 @@ export async function encodeCall(input: EncodeCallInput, network: Network, specV
     return '0x' + Buffer.from(encoded).toString('hex')
 }
 
-export async function encode(requestData: EncodeRequest): Promise<EncodeResponse> {
-    const { call, network: networkInput, spec_version } = requestData
+export async function encodeCalls(inputs: EncodeCallInput[], network: Network, specVersion: number): Promise<string[]> {
+    const runtime = await getRuntimeCached(network, specVersion)
+
+    return inputs.map((input) => encodeCallWithRuntime(input, runtime))
+}
+
+export async function encode(requestData: EncodeRequest): Promise<EncodeResponse | EncodeResponse[]> {
+    const { call, calls, network: networkInput, spec_version } = requestData
 
     const resolved = networkInput ? resolveNetwork(networkInput) : null
     if (networkInput && !resolved) {
@@ -43,5 +54,10 @@ export async function encode(requestData: EncodeRequest): Promise<EncodeResponse
         return { encoded, network, spec_version: specVersion }
     }
 
-    throw new Error('Invalid request: no call provided')
+    if (calls && calls.length > 0) {
+        const results = await encodeCalls(calls, network, specVersion)
+        return results.map((encoded) => ({ encoded, network, spec_version: specVersion }))
+    }
+
+    throw new Error('Invalid request: no call or calls provided')
 }

--- a/src/encoder/types.ts
+++ b/src/encoder/types.ts
@@ -9,6 +9,7 @@ export interface EncodeCallInput {
 
 export interface EncodeRequest {
     call?: EncodeCallInput
+    calls?: EncodeCallInput[]
     network?: string
     spec_version?: number
 }

--- a/tests/encoder-core.test.ts
+++ b/tests/encoder-core.test.ts
@@ -1,0 +1,27 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { encode } from '~/encoder/core'
+
+const calls = [
+    { pallet: 'System', name: 'remark', args: { remark: '0x6b6579' } },
+    { pallet: 'System', name: 'remark', args: { remark: '0x76616c7565' } },
+]
+
+void test('encode returns one result per call for a batch, matching single-call encoding', async () => {
+    const batch = await encode({ calls })
+
+    assert.ok(Array.isArray(batch))
+    assert.equal(batch.length, calls.length)
+
+    for (const [index, call] of calls.entries()) {
+        const single = await encode({ call })
+
+        assert.ok(!Array.isArray(single))
+        assert.deepEqual(batch[index], single)
+        assert.match(batch[index].encoded, /^0x[0-9a-f]+$/)
+    }
+})
+
+void test('encode rejects a request with neither call nor calls', async () => {
+    await assert.rejects(encode({}), { message: 'Invalid request: no call or calls provided' })
+})

--- a/tests/encoder-validation.test.ts
+++ b/tests/encoder-validation.test.ts
@@ -1,0 +1,72 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { validateEncodeRequest } from '~/decoder/validation'
+
+const call = { pallet: 'MultiTokens', name: 'transfer', args: { amount: '1' } }
+
+void test('validateEncodeRequest accepts a single call', () => {
+    const result = validateEncodeRequest({ call })
+
+    assert.ok(result.valid)
+    assert.deepEqual(result.data.call, call)
+    assert.equal(result.data.calls, undefined)
+})
+
+void test('validateEncodeRequest accepts an array of calls', () => {
+    const result = validateEncodeRequest({ calls: [call, { pallet: 'Balances', name: 'transfer_all' }] })
+
+    assert.ok(result.valid)
+    assert.equal(result.data.call, undefined)
+    assert.equal(result.data.calls?.length, 2)
+    assert.deepEqual(result.data.calls[0], call)
+})
+
+void test('validateEncodeRequest rejects a body with neither call nor calls', () => {
+    assert.deepEqual(validateEncodeRequest({ network: 'canary' }), {
+        valid: false,
+        error: 'Missing "call" or "calls" field',
+    })
+})
+
+void test('validateEncodeRequest rejects a non-array calls field', () => {
+    assert.deepEqual(validateEncodeRequest({ calls: call }), {
+        valid: false,
+        error: '"calls" must be an array',
+    })
+})
+
+void test('validateEncodeRequest rejects an empty calls array', () => {
+    assert.deepEqual(validateEncodeRequest({ calls: [] }), {
+        valid: false,
+        error: '"calls" must not be empty',
+    })
+})
+
+void test('validateEncodeRequest reports the offending index for an invalid batch item', () => {
+    assert.deepEqual(validateEncodeRequest({ calls: [call, { pallet: 'MultiTokens' }] }), {
+        valid: false,
+        error: '"calls[1].name" must be a non-empty string',
+    })
+
+    assert.deepEqual(validateEncodeRequest({ calls: ['not-an-object'] }), {
+        valid: false,
+        error: '"calls[0]" must be an object',
+    })
+})
+
+void test('validateEncodeRequest still rejects invalid single-call fields', () => {
+    assert.deepEqual(validateEncodeRequest({ call: [call] }), {
+        valid: false,
+        error: '"call" must be an object',
+    })
+
+    assert.deepEqual(validateEncodeRequest({ call: { pallet: '', name: 'transfer' } }), {
+        valid: false,
+        error: '"call.pallet" must be a non-empty string',
+    })
+
+    assert.deepEqual(validateEncodeRequest({ call: { pallet: 'MultiTokens', name: 'transfer', args: [] } }), {
+        valid: false,
+        error: '"call.args" must be an object',
+    })
+})


### PR DESCRIPTION
Companion to [enjin/platform-cloud#140](https://github.com/enjin/platform-cloud/pull/140), prompted by review feedback there: fuel-tank sweeps now create one transaction per call, so the platform encodes N calls per sweep — currently N HTTP round-trips, since `/encoder` accepts exactly one `call`.

## Change

Mirror the `/decoder` convention (`call` / `calls`) on `/encoder`:

- **Request** — alongside the existing `call` object, accept `calls`: a non-empty array of `{pallet, name, args}`.
- **Response** — for `calls`, a positional array of the same per-call objects the single form returns: `[{encoded, network, spec_version}, ...]`.
- **Runtime resolved once per batch** — `encodeCalls` mirrors `decodeCalls`, so a batch amortizes the `getRuntimeCached` lookup as well as the HTTP overhead.
- **Validation** — batch item errors name the offending index (`"calls[1].name" must be a non-empty string`); an empty array is rejected.

Single-call requests are byte-for-byte unchanged (`encodeCall` now delegates to the shared `encodeCallWithRuntime`).

## Tests

- `tests/encoder-core.test.ts` — a batch result matches element-wise what single-call encoding produces; the no-input error message.
- `tests/encoder-validation.test.ts` — single/batch acceptance, non-array/empty rejection, per-index error reporting, and the pre-existing single-call rejections.

`npm test` 34/34 · `tsc --noEmit` clean · `ci:lint` clean.

## Notes for reviewers

- `express.json({ limit: '1mb' })` still applies. A worst-case sweep batch (250 `batch_transfer` calls × 250 recipients) could exceed it; clients must chunk oversized batches. Left unchanged deliberately — flag if you'd rather bump it here.
- **Deploy order now matters:** platform-cloud consumes `calls` as of [enjin/platform-cloud#140](https://github.com/enjin/platform-cloud/pull/140) (commit `8b0db370`) for managed-wallet sweeps. This PR must be **deployed to the codec service before** #140 reaches production, or sweep encoding there fails with a 400. All other platform paths still send single-`call` requests and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
