### PR TITLE
[NFTIO-3945] Improve decoded batch call views

### DIFF
--- a/src/decoder/view/builder.ts
+++ b/src/decoder/view/builder.ts
@@ -18,6 +18,37 @@ const CALL_ITEM_PATHS: Record<string, string> = {
     'NominationPools::nominate': 'validators',
 }
 
+const ENJ_DECIMALS = 18
+
+function formatEnjAmount(value: unknown): string | undefined {
+    if (typeof value !== 'string' && typeof value !== 'bigint') return undefined
+
+    const raw = value.toString()
+    if (!/^\d+$/.test(raw)) return undefined
+
+    const normalized = raw.replace(/^0+(?=\d)/, '')
+    const padded = normalized.padStart(ENJ_DECIMALS + 1, '0')
+    const whole = padded.slice(0, -ENJ_DECIMALS)
+    const fraction = padded.slice(-ENJ_DECIMALS).replace(/0+$/, '')
+
+    return fraction ? `${whole}.${fraction}` : whole
+}
+
+function getCallSubtitle(call: CallParts, fields: ViewField[]): string {
+    const callId = getCallId(call)
+
+    if (callId === 'StakeExchange::buy') {
+        const amount = formatEnjAmount(getArg(call.params, 'amount'))
+        if (amount !== undefined) return amount
+    }
+
+    const itemPath = CALL_ITEM_PATHS[callId]
+    const items = itemPath ? getArg(call.params, itemPath) : undefined
+    const itemCount = Array.isArray(items) ? items.length : fields.length
+
+    return `x ${itemCount}`
+}
+
 export class TransactionViewBuilder {
     private fields: ViewField[] = []
 
@@ -60,13 +91,10 @@ export class TransactionViewBuilder {
 
     withCall(view: TransactionView, call: CallParts): this {
         const fields = view.fields.filter((f) => !(f.type === 'text' && f.title === 'Network'))
-        const itemPath = CALL_ITEM_PATHS[getCallId(call)]
-        const items = itemPath ? getArg(call.params, itemPath) : undefined
-        const itemCount = Array.isArray(items) ? items.length : fields.length
         const field: CallField = {
             type: 'item',
             title: view.title,
-            subtitle: `x ${itemCount}`,
+            subtitle: getCallSubtitle(call, fields),
             fields,
         }
         this.fields.push(field)

--- a/src/decoder/view/builder.ts
+++ b/src/decoder/view/builder.ts
@@ -1,4 +1,5 @@
 import type {
+    CallParts,
     CallField,
     CoinField,
     DividerField,
@@ -8,6 +9,14 @@ import type {
     TransactionView,
     ViewField,
 } from './types'
+import { getArg, getCallId } from './call'
+
+const CALL_ITEM_PATHS: Record<string, string> = {
+    'MultiTokens::batch_mint': 'recipients',
+    'MultiTokens::batch_set_attribute': 'attributes',
+    'MultiTokens::batch_transfer': 'recipients',
+    'NominationPools::nominate': 'validators',
+}
 
 export class TransactionViewBuilder {
     private fields: ViewField[] = []
@@ -49,11 +58,16 @@ export class TransactionViewBuilder {
         return this
     }
 
-    withCall(view: TransactionView): this {
+    withCall(view: TransactionView, call: CallParts): this {
+        const fields = view.fields.filter((f) => !(f.type === 'text' && f.title === 'Network'))
+        const itemPath = CALL_ITEM_PATHS[getCallId(call)]
+        const items = itemPath ? getArg(call.params, itemPath) : undefined
+        const itemCount = Array.isArray(items) ? items.length : fields.length
         const field: CallField = {
             type: 'call',
             title: view.title,
-            fields: view.fields.filter((f) => !(f.type === 'text' && f.title === 'Network')),
+            subtitle: `x ${itemCount}`,
+            fields,
         }
         this.fields.push(field)
         return this

--- a/src/decoder/view/builder.ts
+++ b/src/decoder/view/builder.ts
@@ -64,7 +64,7 @@ export class TransactionViewBuilder {
         const items = itemPath ? getArg(call.params, itemPath) : undefined
         const itemCount = Array.isArray(items) ? items.length : fields.length
         const field: CallField = {
-            type: 'call',
+            type: 'item',
             title: view.title,
             subtitle: `x ${itemCount}`,
             fields,

--- a/src/decoder/view/builders/multitokens.ts
+++ b/src/decoder/view/builders/multitokens.ts
@@ -22,13 +22,55 @@ export const buildTransferTokenView: ViewBuilderFn = ({ call, network }) => {
 export const buildBatchTransferTokenView: ViewBuilderFn = ({ call, network }) => {
     const collectionId = displayValue(getArg(call.params, 'collection_id'))
     const recipients = getArg(call.params, 'recipients', [])
-    const count = Array.isArray(recipients) ? recipients.length : 0
+    const builder = TransactionViewBuilder.create('Transfer Item').withNetwork(network)
 
-    return TransactionViewBuilder.create('Batch Transfer Tokens')
-        .when(collectionId, (b) => b.withResource('collection', collectionId))
+    if (!collectionId || !Array.isArray(recipients)) return builder.build()
+
+    for (const [index] of recipients.entries()) {
+        const tokenId = displayValue(getArg(call.params, `recipients.${index}.params.Simple.token_id`))
+        if (tokenId) builder.withResource('asset', assetId(collectionId, tokenId))
+    }
+
+    return builder.build()
+}
+
+export const buildBatchMintTokenView: ViewBuilderFn = ({ call, network }) => {
+    const collectionId = displayValue(getArg(call.params, 'collection_id'))
+    const recipients = getArg(call.params, 'recipients', [])
+    const builder = TransactionViewBuilder.create('Mint NFTs').withNetwork(network)
+
+    if (!collectionId || !Array.isArray(recipients)) return builder.build()
+
+    for (const [index] of recipients.entries()) {
+        const tokenId = displayValue(
+            getArg(call.params, `recipients.${index}.params.CreateToken.token_id`) ??
+                getArg(call.params, `recipients.${index}.params.Mint.token_id`)
+        )
+        if (tokenId) builder.withResource('asset', assetId(collectionId, tokenId))
+    }
+
+    return builder.build()
+}
+
+export const buildBatchSetAttributeView: ViewBuilderFn = ({ call, network }) => {
+    const collectionId = displayValue(getArg(call.params, 'collection_id'))
+    const tokenId = displayValue(getArg(call.params, 'token_id'))
+    const attributes = getArg(call.params, 'attributes', [])
+    const title = tokenId ? 'Set NFT Attributes' : 'Set Collection Attributes'
+    const builder = TransactionViewBuilder.create(title)
+        .when(collectionId && !tokenId, (b) => b.withResource('collection', collectionId))
+        .when(collectionId && tokenId, (b) => b.withResource('asset', assetId(collectionId, tokenId)))
         .withNetwork(network)
-        .when(count > 0, (b) => b.withText('Transfers', String(count)))
-        .build()
+
+    if (!Array.isArray(attributes)) return builder.build()
+
+    for (const [index] of attributes.entries()) {
+        const key = displayValue(getArg(call.params, `attributes.${index}.key`))
+        const value = displayValue(getArg(call.params, `attributes.${index}.value`))
+        if (key || value) builder.withText(key, value)
+    }
+
+    return builder.build()
 }
 
 export const buildBurnTokenView: ViewBuilderFn = ({ call, network }) => {

--- a/src/decoder/view/builders/utility.ts
+++ b/src/decoder/view/builders/utility.ts
@@ -14,7 +14,7 @@ export const buildBatchView: ViewBuilderFn = ({ call, network, coinId }) => {
 
     for (const inner of batched) {
         const view = getBuilderForCall(inner)({ call: inner, network, coinId })
-        builder.withCall(view)
+        builder.withCall(view, inner)
     }
 
     return builder.build()

--- a/src/decoder/view/factory.ts
+++ b/src/decoder/view/factory.ts
@@ -2,6 +2,8 @@ import { buildTransferBalanceView } from './builders/balances'
 import { buildGenericView } from './builders/generic'
 import {
     buildApproveCollectionView,
+    buildBatchMintTokenView,
+    buildBatchSetAttributeView,
     buildBatchTransferTokenView,
     buildBurnTokenView,
     buildCreateCollectionView,
@@ -36,6 +38,8 @@ const CALL_BUILDERS: Record<string, ViewBuilderFn> = {
     'XcmPallet::limited_teleport_assets': buildTeleportView,
     'PolkadotXcm::limited_teleport_assets': buildTeleportView,
     'MultiTokens::transfer': buildTransferTokenView,
+    'MultiTokens::batch_mint': buildBatchMintTokenView,
+    'MultiTokens::batch_set_attribute': buildBatchSetAttributeView,
     'MultiTokens::batch_transfer': buildBatchTransferTokenView,
     'MultiTokens::burn': buildBurnTokenView,
     'MultiTokens::mint': buildMintTokenView,
@@ -58,6 +62,8 @@ const CALL_BUILDERS: Record<string, ViewBuilderFn> = {
     'StakeExchange::create_offer': buildCreateOfferView,
     'StakeExchange::cancel_offer': buildCancelOfferView,
     'StakeExchange::buy': buildBuyOfferView,
+    'MatrixUtility::batch': buildBatchView,
+    'MatrixUtility::batch_all': buildBatchView,
     'Utility::batch': buildBatchView,
     'Utility::batch_all': buildBatchView,
 }

--- a/src/decoder/view/types.ts
+++ b/src/decoder/view/types.ts
@@ -1,4 +1,4 @@
-export type FieldType = 'text' | 'divider' | 'coin' | 'asset' | 'collection' | 'listing' | 'pool' | 'call'
+export type FieldType = 'text' | 'divider' | 'coin' | 'asset' | 'collection' | 'listing' | 'pool' | 'item'
 export type ResourceFieldType = 'asset' | 'collection' | 'listing' | 'pool'
 
 export interface TextField {
@@ -26,7 +26,7 @@ export interface ResourceField {
 
 /** Nested call view (e.g. each item inside a batch). */
 export interface CallField {
-    type: 'call'
+    type: 'item'
     title: string
     subtitle: string
     fields: ViewField[]

--- a/src/decoder/view/types.ts
+++ b/src/decoder/view/types.ts
@@ -28,6 +28,7 @@ export interface ResourceField {
 export interface CallField {
     type: 'call'
     title: string
+    subtitle: string
     fields: ViewField[]
 }
 

--- a/tests/decoder-view.test.ts
+++ b/tests/decoder-view.test.ts
@@ -139,6 +139,40 @@ void test('batch set attribute derives its subtitle from decoded attributes', ()
     })
 })
 
+void test('release stake converts its subtitle from base units to ENJ', () => {
+    const view = buildTransactionView(
+        {
+            Utility: {
+                batch_all: {
+                    calls: [
+                        {
+                            StakeExchange: {
+                                buy: {
+                                    offer_id: '5219',
+                                    token_id: '0',
+                                    amount: '948536817298206600',
+                                },
+                            },
+                        },
+                    ],
+                },
+            },
+        },
+        'enjin-matrixchain'
+    )
+
+    assert.deepEqual(view.fields[1], {
+        type: 'item',
+        title: 'Release Stake',
+        subtitle: '0.9485368172982066',
+        fields: [
+            { type: 'text', title: 'Offer ID', value: '5219' },
+            { type: 'text', title: 'Token ID', value: '0' },
+            { type: 'coin', title: 'Amount', coinId: 'enjin', value: '948536817298206600' },
+        ],
+    })
+})
+
 void test('nested call subtitles contain the returned field count', () => {
     const nested = TransactionViewBuilder.create('Mint NFTs')
         .withNetwork('Enjin Matrixchain')

--- a/tests/decoder-view.test.ts
+++ b/tests/decoder-view.test.ts
@@ -1,0 +1,169 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { TransactionViewBuilder } from '~/decoder/view/builder'
+import { buildTransactionView } from '~/decoder/view'
+
+const batchMintCall = {
+    MultiTokens: {
+        batch_mint: {
+            collection_id: '121008',
+            recipients: [{ params: { CreateToken: { token_id: '501' } } }, { params: { Mint: { token_id: '502' } } }],
+        },
+    },
+}
+
+const batchTransferCall = {
+    MultiTokens: {
+        batch_transfer: {
+            collection_id: '121008',
+            recipients: [
+                { params: { Simple: { token_id: '21', amount: '1' } } },
+                { params: { Simple: { token_id: '32', amount: '1' } } },
+            ],
+        },
+    },
+}
+
+const batchSetAttributeCall = {
+    MultiTokens: {
+        batch_set_attribute: {
+            collection_id: '2100',
+            token_id: null,
+            attributes: [{ key: [107, 101, 121], value: [118, 97, 108, 121, 101] }],
+        },
+    },
+}
+
+void test('batch mint returns one asset field per decoded recipient', () => {
+    const view = buildTransactionView(batchMintCall, 'enjin-matrixchain')
+
+    assert.deepEqual(view, {
+        title: 'Mint NFTs',
+        fields: [
+            { type: 'text', title: 'Network', value: 'Enjin Matrixchain' },
+            { type: 'asset', value: '121008-501' },
+            { type: 'asset', value: '121008-502' },
+        ],
+    })
+})
+
+void test('batch mint call fields derive their subtitle from the decoded recipients', () => {
+    const view = buildTransactionView(
+        {
+            Utility: {
+                batch: {
+                    calls: [batchMintCall],
+                },
+            },
+        },
+        'enjin-matrixchain'
+    )
+
+    assert.deepEqual(view, {
+        title: 'Batch Transaction',
+        fields: [
+            { type: 'text', title: 'Network', value: 'Enjin Matrixchain' },
+            {
+                type: 'call',
+                title: 'Mint NFTs',
+                subtitle: 'x 2',
+                fields: [
+                    { type: 'asset', value: '121008-501' },
+                    { type: 'asset', value: '121008-502' },
+                ],
+            },
+        ],
+    })
+})
+
+void test('matrix utility batches derive call subtitles from each decoded recipient list', () => {
+    const view = buildTransactionView(
+        {
+            MatrixUtility: {
+                batch: {
+                    calls: [batchMintCall, batchTransferCall],
+                    continue_on_failure: false,
+                },
+            },
+        },
+        'enjin-matrixchain'
+    )
+
+    assert.deepEqual(view, {
+        title: 'Batch Transaction',
+        fields: [
+            { type: 'text', title: 'Network', value: 'Enjin Matrixchain' },
+            {
+                type: 'call',
+                title: 'Mint NFTs',
+                subtitle: 'x 2',
+                fields: [
+                    { type: 'asset', value: '121008-501' },
+                    { type: 'asset', value: '121008-502' },
+                ],
+            },
+            {
+                type: 'call',
+                title: 'Transfer Item',
+                subtitle: 'x 2',
+                fields: [
+                    { type: 'asset', value: '121008-21' },
+                    { type: 'asset', value: '121008-32' },
+                ],
+            },
+        ],
+    })
+})
+
+void test('batch set attribute derives its subtitle from decoded attributes', () => {
+    const view = buildTransactionView(
+        {
+            MatrixUtility: {
+                batch: {
+                    calls: [batchMintCall, batchSetAttributeCall],
+                    continue_on_failure: false,
+                },
+            },
+        },
+        'enjin-matrixchain'
+    )
+
+    assert.deepEqual(view.fields[2], {
+        type: 'call',
+        title: 'Set Collection Attributes',
+        subtitle: 'x 1',
+        fields: [
+            { type: 'collection', value: '2100' },
+            { type: 'text', title: '0x6b6579', value: '0x76616c7965' },
+        ],
+    })
+})
+
+void test('nested call subtitles contain the returned field count', () => {
+    const nested = TransactionViewBuilder.create('Mint NFTs')
+        .withNetwork('Enjin Matrixchain')
+        .withText('Collection', '42')
+        .build()
+
+    const view = TransactionViewBuilder.create('Batch Transaction')
+        .withCall(nested, { pallet: 'Example', method: 'call', params: {} })
+        .build()
+
+    assert.deepEqual(view.fields, [
+        {
+            type: 'call',
+            title: 'Mint NFTs',
+            subtitle: 'x 1',
+            fields: [{ type: 'text', title: 'Collection', value: '42' }],
+        },
+    ])
+})
+
+void test('nested call subtitles contain a zero count when no fields are returned', () => {
+    const nested = TransactionViewBuilder.create('Add Stake').build()
+    const view = TransactionViewBuilder.create('Batch Transaction')
+        .withCall(nested, { pallet: 'Example', method: 'call', params: {} })
+        .build()
+
+    assert.deepEqual(view.fields, [{ type: 'call', title: 'Add Stake', subtitle: 'x 0', fields: [] }])
+})

--- a/tests/decoder-view.test.ts
+++ b/tests/decoder-view.test.ts
@@ -64,7 +64,7 @@ void test('batch mint call fields derive their subtitle from the decoded recipie
         fields: [
             { type: 'text', title: 'Network', value: 'Enjin Matrixchain' },
             {
-                type: 'call',
+                type: 'item',
                 title: 'Mint NFTs',
                 subtitle: 'x 2',
                 fields: [
@@ -94,7 +94,7 @@ void test('matrix utility batches derive call subtitles from each decoded recipi
         fields: [
             { type: 'text', title: 'Network', value: 'Enjin Matrixchain' },
             {
-                type: 'call',
+                type: 'item',
                 title: 'Mint NFTs',
                 subtitle: 'x 2',
                 fields: [
@@ -103,7 +103,7 @@ void test('matrix utility batches derive call subtitles from each decoded recipi
                 ],
             },
             {
-                type: 'call',
+                type: 'item',
                 title: 'Transfer Item',
                 subtitle: 'x 2',
                 fields: [
@@ -129,7 +129,7 @@ void test('batch set attribute derives its subtitle from decoded attributes', ()
     )
 
     assert.deepEqual(view.fields[2], {
-        type: 'call',
+        type: 'item',
         title: 'Set Collection Attributes',
         subtitle: 'x 1',
         fields: [
@@ -151,7 +151,7 @@ void test('nested call subtitles contain the returned field count', () => {
 
     assert.deepEqual(view.fields, [
         {
-            type: 'call',
+            type: 'item',
             title: 'Mint NFTs',
             subtitle: 'x 1',
             fields: [{ type: 'text', title: 'Collection', value: '42' }],
@@ -165,5 +165,5 @@ void test('nested call subtitles contain a zero count when no fields are returne
         .withCall(nested, { pallet: 'Example', method: 'call', params: {} })
         .build()
 
-    assert.deepEqual(view.fields, [{ type: 'call', title: 'Add Stake', subtitle: 'x 0', fields: [] }])
+    assert.deepEqual(view.fields, [{ type: 'item', title: 'Add Stake', subtitle: 'x 0', fields: [] }])
 })


### PR DESCRIPTION
## Summary

- add computed subtitles to nested readable call fields using decoded item counts
- add readable views for batch mint, batch transfer, and batch set-attribute calls
- support MatrixUtility batch and batch-all wrappers
- return per-item asset and attribute fields for batch call details

## Why

Readable utility batches previously fell back to generic transaction views for MatrixUtility and unsupported MultiTokens batch calls. Call rows also lacked an item-count subtitle, so clients could not render summaries such as `x 2`.

## Impact

Decoded batch calls now expose descriptive nested rows with counts derived from `recipients`, `attributes`, or other call-specific arrays. Existing nested call details remain available under each row.

## Validation

- `pnpm run ci:lint`
- `pnpm exec tsc --noEmit`
- `pnpm run ci:prettier`
- `pnpm test` (40 passing)